### PR TITLE
Up the maximum for a Job ID length to 6

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -7,7 +7,7 @@ class Job < ApplicationRecord
   validates :position, presence: true
   validates :location, presence: true
   validates :openings, presence: true, format: { with: /\A\d+\z/ }
-  validates_length_of :jobId, :minimum => 5, :maximum => 5
+  validates_length_of :jobId, :minimum => 5, :maximum => 6
   validates_length_of :company, :maximum => 40
   validates_length_of :position, :maximum => 100
   validates_length_of :location, :maximum => 40


### PR DESCRIPTION
Fixes #5.